### PR TITLE
Send logs to stdout/stderr

### DIFF
--- a/kong-salemove.Dockerfile
+++ b/kong-salemove.Dockerfile
@@ -2,4 +2,10 @@ FROM kong:0.11-alpine
 
 RUN luarocks install kong-plugin-datadog-tags 0.2.3
 
+# Create symlinks to redirect nginx logs to stdout and stderr docker log collector
+RUN mkdir -p /usr/local/kong/logs \
+  && ln -sf /dev/stdout /usr/local/kong/logs/access.log \
+  && ln -sf /dev/stdout /usr/local/kong/logs/admin_access.log \
+  && ln -sf /dev/stderr /usr/local/kong/logs/error.log
+
 CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]


### PR DESCRIPTION
The approach is copied from [kubernetes/ingress-nginx Dockerfile][1]. It allows
the NGINX worker processes to keep sending their logs to the default log files,
but also supports collecting these logs in e.g. Kubernetes.

[1]: https://github.com/kubernetes/ingress-nginx/blob/1b5db4b3b0371f4192c94bc230c855ea5e33ffac/rootfs/Dockerfile#L25-L29

