### PR TITLE
Revert "Send logs to stdout/stderr" and add tini

### DIFF
--- a/kong-salemove.Dockerfile
+++ b/kong-salemove.Dockerfile
@@ -2,10 +2,4 @@ FROM kong:0.11-alpine
 
 RUN luarocks install kong-plugin-datadog-tags 0.2.3
 
-# Create symlinks to redirect nginx logs to stdout and stderr docker log collector
-RUN mkdir -p /usr/local/kong/logs \
-  && ln -sf /dev/stdout /usr/local/kong/logs/access.log \
-  && ln -sf /dev/stdout /usr/local/kong/logs/admin_access.log \
-  && ln -sf /dev/stderr /usr/local/kong/logs/error.log
-
 CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]

--- a/kong-salemove.Dockerfile
+++ b/kong-salemove.Dockerfile
@@ -1,5 +1,8 @@
 FROM kong:0.11-alpine
 
-RUN luarocks install kong-plugin-datadog-tags 0.2.3
+RUN RUN apk add --no-cache tini \
+  && luarocks install kong-plugin-datadog-tags 0.2.3
+
+ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]
 
 CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]


### PR DESCRIPTION
This reverts commit 6d94aa7f861a7d820aa47f14de6190d97efd5e71, because it wasn't
really needed - Kong environment variables such as `KONG_PROXY_ACCESS_LOG` are
enough for logging to stdout/stderr when needed. The problem in our case was
that the NGINX process that did the logging wasn't started as the main
container process, but was started by `kong start` and so it had its own
stdout, which wasn't collected by Docker.

Tini is added because the actual entrypoint `/docker-entrypoint.sh` is a shell
script which isn't guaranteed to handle signals properly. This is also helps in
cases where the CMD has to be an additional `/bin/sh` execution, e.g. to
explicitly run `kong prepare` before starting NGINX.